### PR TITLE
Add support for multiple rate limits per key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,16 +22,6 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.mod') }}
-        restore-keys: |
-          ${{ runner.os }}-go-${{ matrix.go-version }}-
-
     - name: Verify dependencies
       run: go mod verify
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Early days! I am designing a token bucket rate limiter with an emphasis on clean
 go get github.com/clipperhouse/ratelimiter
 ```
 
-[![Tests](https://github.com/clipperhouse/ratelimiter/actions/workflows/test.yml/badge.svg)](https://github.com/clipperhouse/ratelimiter/actions/workflows/test.yml)
+[![Tests](https://github.com/clipperhouse/ratelimiter/actions/workflows/tests.yml/badge.svg)](https://github.com/clipperhouse/ratelimiter/actions/workflows/tests.yml)
 
 ## Sample code
 

--- a/bucket.go
+++ b/bucket.go
@@ -25,7 +25,8 @@ func (b *bucket) allow(now time.Time, limit limit) bool {
 	b.checkMaxTokens(now, limit)
 
 	// Check if enough time has passed such that there is at least one token
-	allow := b.time.Before(now.Add(-limit.durationPerToken))
+	// Using !After to represent "Before or Equal"
+	allow := !b.time.After(now.Add(-limit.durationPerToken))
 	if allow {
 		b.consumeToken(limit)
 	}
@@ -39,7 +40,7 @@ func (b *bucket) consumeToken(limit limit) {
 }
 
 // remainingTokens returns the number of tokens remaining in the bucket
-// only call it for testing our math
+// only current use is for testing our math
 func (b *bucket) remainingTokens(now time.Time, limit limit) int64 {
 	b.checkMaxTokens(now, limit)
 	return int64(now.Sub(b.time) / limit.durationPerToken)

--- a/limit.go
+++ b/limit.go
@@ -1,11 +1,18 @@
 package ratelimiter
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type limit struct {
 	Count            int64
 	Period           time.Duration
 	durationPerToken time.Duration
+}
+
+func (l limit) String() string {
+	return fmt.Sprintf("%d requests per %s", l.Count, l.Period.String())
 }
 
 // NewLimit creates a new limit with the given count and period.

--- a/ratelimiter_test.go
+++ b/ratelimiter_test.go
@@ -87,3 +87,176 @@ func TestRateLimiter_Allow_MultipleBuckets_Concurrent(t *testing.T) {
 		}
 	}
 }
+
+func TestRateLimiter_Allow_MultipleLimits(t *testing.T) {
+	keyer := func(input string) string {
+		return input
+	}
+
+	// Create two limits: 9 per second and 21 per hour
+	limitPerSecond := NewLimit(9, time.Second)
+	limitPerHour := NewLimit(21, time.Hour)
+
+	limiter := NewRateLimiter(keyer, limitPerSecond, limitPerHour)
+	now := time.Now()
+
+	for range 2 {
+		// Test that we can make 9 requests within the first second (limited by per-second limit)
+		for i := range limitPerSecond.Count {
+			require.True(t, limiter.allow("test", now), "request %d should be allowed within per-second limit", i+1)
+		}
+
+		// The 10th request should be rejected due to per-second limit
+		require.False(t, limiter.allow("test", now), "10th request should be rejected due to per-second limit")
+
+		// Continue making requests until we hit the hourly limit
+		for i := range limitPerHour.Count - limitPerSecond.Count {
+			// Add a second between them to ensure we're not hitting the per-second limit
+			now = now.Add(time.Second)
+			require.True(t, limiter.allow("test", now), "request %d should be allowed within hourly limit", i+1)
+		}
+
+		// The next request should be rejected due to hourly limit, we've made 21 total
+		require.False(t, limiter.allow("test", now), "22nd request should be rejected due to hourly limit")
+
+		// Advance time by 1 hour to refill both buckets
+		now = now.Add(time.Hour)
+	}
+}
+
+func TestRateLimiter_Allow_MultipleLimits_MultipleBuckets(t *testing.T) {
+	keyer := func(bucketID int) string {
+		return fmt.Sprintf("bucket-%d", bucketID)
+	}
+
+	// Create two limits: 5 per second and 15 per hour
+	limitPerSecond := NewLimit(5, time.Second)
+	limitPerHour := NewLimit(15, time.Hour)
+	limiter := NewRateLimiter(keyer, limitPerSecond, limitPerHour)
+	const buckets = 7
+
+	now := time.Now()
+
+	for range 3 {
+		// Test that each bucket can use its full per-second limit
+		for bucketID := range buckets {
+			for i := range limitPerSecond.Count {
+				allowed := limiter.allow(bucketID, now)
+				require.True(t, allowed, "bucket %d, request %d should be allowed within per-second limit", bucketID, i+1)
+			}
+
+			// The 6th request should be rejected due to per-second limit
+			allowed := limiter.allow(bucketID, now)
+			require.False(t, allowed, "bucket %d, 6th request should be rejected due to per-second limit", bucketID)
+		}
+
+		// Advance time by 1 second to refill per-second buckets
+		now = now.Add(time.Second)
+	}
+
+	// At this point, each bucket has used 15 tokens (5 per second for 3 seconds)
+	// This should hit the hourly limit for each bucket
+
+	// Advance time by 1 second to refill per-second buckets
+	now = now.Add(time.Second)
+
+	// Try to make requests for each bucket - they should all be rejected due to hourly limit
+	for bucketID := range buckets {
+		allowed := limiter.allow(bucketID, now)
+		require.False(t, allowed, "bucket %d should be rejected due to hourly limit after 15 requests", bucketID)
+	}
+
+	// Advance time by 1 hour to refill hourly buckets
+	now = now.Add(time.Hour)
+
+	// Test that each bucket can use its full per-second limit again after hourly refill
+	for bucketID := range buckets {
+		for i := range limitPerSecond.Count {
+			allowed := limiter.allow(bucketID, now)
+			require.True(t, allowed, "bucket %d, request %d should be allowed after hourly refill", bucketID, i+1)
+		}
+
+		// The 6th request should be rejected due to per-second limit
+		allowed := limiter.allow(bucketID, now)
+		require.False(t, allowed, "bucket %d, 6th request should be rejected after hourly refill", bucketID)
+	}
+}
+
+func TestRateLimiter_Allow_MultipleLimits_MultipleBuckets_Concurrent(t *testing.T) {
+	keyer := func(bucketID int) string {
+		return fmt.Sprintf("bucket-%d", bucketID)
+	}
+
+	// Create two limits: 5 per second and 15 per hour
+	limitPerSecond := NewLimit(5, time.Second)
+	limitPerHour := NewLimit(15, time.Hour)
+	limiter := NewRateLimiter(keyer, limitPerSecond, limitPerHour)
+	const buckets = 7
+
+	now := time.Now()
+
+	for round := range 3 {
+		// Test that each bucket can use its full per-second limit concurrently
+		var wg sync.WaitGroup
+		for bucketID := range buckets {
+			for i := range limitPerSecond.Count {
+				wg.Add(1)
+				go func(bucketID int, requestID int64) {
+					defer wg.Done()
+					allowed := limiter.allow(bucketID, now)
+					require.True(t, allowed, "round %d, bucket %d, request %d should be allowed within per-second limit", round+1, bucketID, requestID+1)
+				}(bucketID, i)
+			}
+		}
+		wg.Wait()
+
+		// The 6th request should be rejected due to per-second limit for each bucket
+		for bucketID := range buckets {
+			allowed := limiter.allow(bucketID, now)
+			require.False(t, allowed, "round %d, bucket %d, 6th request should be rejected due to per-second limit", round+1, bucketID)
+		}
+
+		// Advance time by 1 second to refill per-second buckets
+		now = now.Add(time.Second)
+	}
+
+	// At this point, each bucket has used 15 tokens (5 per second for 3 seconds)
+	// This should hit the hourly limit for each bucket
+
+	// Advance time by 1 second to refill per-second buckets
+	now = now.Add(time.Second)
+
+	// Try to make requests for each bucket concurrently - they should all be rejected due to hourly limit
+	var wg sync.WaitGroup
+	for bucketID := range buckets {
+		wg.Add(1)
+		go func(bucketID int) {
+			defer wg.Done()
+			allowed := limiter.allow(bucketID, now)
+			require.False(t, allowed, "bucket %d should be rejected due to hourly limit after 15 requests", bucketID)
+		}(bucketID)
+	}
+	wg.Wait()
+
+	// Advance time by 1 hour to refill hourly buckets
+	now = now.Add(time.Hour)
+
+	// Test that each bucket can use its full per-second limit again after hourly refill, concurrently
+	for bucketID := range buckets {
+		for i := range limitPerSecond.Count {
+			wg.Add(1)
+			go func(bucketID int, requestID int64) {
+				defer wg.Done()
+				allowed := limiter.allow(bucketID, now)
+				require.True(t, allowed, "bucket %d, request %d should be allowed after hourly refill", bucketID, requestID+1)
+			}(bucketID, i)
+		}
+	}
+	wg.Wait()
+
+	// The 6th request should be rejected due to per-second limit for each bucket
+	for bucketID := range buckets {
+		allowed := limiter.allow(bucketID, now)
+		require.False(t, allowed, "bucket %d, 6th request should be rejected after hourly refill", bucketID)
+	}
+}


### PR DESCRIPTION
Refactored RateLimiter to accept multiple limits, allowing each key to be subject to several independent rate limits (e.g., per-second and per-hour).

Updated internal data structures for thread safety and to manage multiple limit buckets.

Added tests for multiple limits, multiple keys, and concurrent scenarios. Minor doc and comment improvements.